### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/AzureWizardLearn/a7700b0d-6162-4395-b632-a26435f61424/282254f0-224a-470d-a6d5-cc9ee6aea05b/_apis/work/boardbadge/315431a8-ca0d-4447-9751-65bcaa5e7eb6)](https://dev.azure.com/AzureWizardLearn/a7700b0d-6162-4395-b632-a26435f61424/_boards/board/t/282254f0-224a-470d-a6d5-cc9ee6aea05b/Microsoft.RequirementCategory)
 # Ultimate DevSecOps library
 
 ## Contribution rules


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#800](https://dev.azure.com/AzureWizardLearn/a7700b0d-6162-4395-b632-a26435f61424/_workitems/edit/800). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.